### PR TITLE
Access code invalidation - re-enable access code happy-path-tests

### DIFF
--- a/src/main/routes/enter-access-code.ts
+++ b/src/main/routes/enter-access-code.ts
@@ -274,7 +274,14 @@ export default function setupEnterAccessCodeRoute(app: Application): void {
 
       // Invalidating access code
       try {
-        const invalidCaseData = await invalidateAccessCode(caseData, trimmedAccessCode, role, req.session.caseNumber);
+        let invalidCaseData: FinremCaseData;
+        if (process.env.ENABLE_TEST_SUPPORT_ROUTES === 'true') {
+          // In test mode, skip the CCD triggerEvent call and apply the update locally
+          const partialUpdate = getInvalidateAccessCodeData(caseData, trimmedAccessCode, role);
+          invalidCaseData = { ...caseData, ...partialUpdate };
+        } else {
+          invalidCaseData = await invalidateAccessCode(caseData, trimmedAccessCode, role, req.session.caseNumber);
+        }
         req.session.caseData = invalidCaseData;
       } catch {
         res.render(ViewNames.Error);

--- a/src/test/functional/specFiles/enterAccessCode.spec.ts
+++ b/src/test/functional/specFiles/enterAccessCode.spec.ts
@@ -143,15 +143,8 @@ test.describe('Enter Access Code - Happy Path', () => {
   /**
    * Citizen successfully enters valid applicant access code and views case
    * [mock] Uses hardcoded access codes injected via test session endpoint.
-   * 
-   * TODO: RESOLVE - Currently skipped due to implementation of invalidating access code (PR #347).
-   * The mock test framework does not properly mock the CCD triggerEvent() call required for access code invalidation.
-   * When a valid access code is submitted, the system now calls invalidateAccessCode() which triggers a CCD event.
-   * This test requires either:
-   * 1. Mock support for CCD API triggerEvent() in the test framework, or
-   * 2. Bypass access code invalidation in mock test mode via MOCK_INVALIDATE_ACCESS_CODE=false flag
    */
-  test.skip('[mock] Citizen can enter valid applicant access code and view case summary', async ({
+  test('[mock] Citizen can enter valid applicant access code and view case summary', async ({
     loggedInPage: _loggedInPage,
     dashboardPage,
     enterAccessCodePage,
@@ -167,15 +160,8 @@ test.describe('Enter Access Code - Happy Path', () => {
   /**
    * Verify whitespace is trimmed from access code
    * [mock] Uses hardcoded access codes injected via test session endpoint.
-   * 
-   * TODO: RESOLVE - Currently skipped due to implementation of invalidating access code (PR #347).
-   * The mock test framework does not properly mock the CCD triggerEvent() call required for access code invalidation.
-   * When a valid access code is submitted, the system now calls invalidateAccessCode() which triggers a CCD event.
-   * This test requires either:
-   * 1. Mock support for CCD API triggerEvent() in the test framework, or
-   * 2. Bypass access code invalidation in mock test mode via MOCK_INVALIDATE_ACCESS_CODE=false flag
    */
-  test.skip('[mock] Success: Access code with leading/trailing whitespace is accepted', async ({
+  test('[mock] Success: Access code with leading/trailing whitespace is accepted', async ({
     loggedInPage: _loggedInPage,
     dashboardPage,
     enterAccessCodePage,
@@ -190,15 +176,8 @@ test.describe('Enter Access Code - Happy Path', () => {
   /**
    * Citizen successfully enters valid respondent access code and views case
    * [mock] Uses hardcoded access codes injected via test session endpoint.
-   * 
-   * TODO: RESOLVE - Currently skipped due to implementation of invalidating access code (PR #347).
-   * The mock test framework does not properly mock the CCD triggerEvent() call required for access code invalidation.
-   * When a valid access code is submitted, the system now calls invalidateAccessCode() which triggers a CCD event.
-   * This test requires either:
-   * 1. Mock support for CCD API triggerEvent() in the test framework, or
-   * 2. Bypass access code invalidation in mock test mode via MOCK_INVALIDATE_ACCESS_CODE=false flag
    */
-  test.skip('[mock] Citizen can enter valid respondent access code and view case summary', async ({
+  test('[mock] Citizen can enter valid respondent access code and view case summary', async ({
     loggedInPage: _loggedInPage,
     dashboardPage,
     enterAccessCodePage,
@@ -213,15 +192,8 @@ test.describe('Enter Access Code - Happy Path', () => {
   /**
    * Access codes are case-insensitive
    * [mock] Uses hardcoded access codes injected via test session endpoint.
-   * 
-   * TODO: RESOLVE - Currently skipped due to implementation of invalidating access code (PR #347).
-   * The mock test framework does not properly mock the CCD triggerEvent() call required for access code invalidation.
-   * When a valid access code is submitted, the system now calls invalidateAccessCode() which triggers a CCD event.
-   * This test requires either:
-   * 1. Mock support for CCD API triggerEvent() in the test framework, or
-   * 2. Bypass access code invalidation in mock test mode via MOCK_INVALIDATE_ACCESS_CODE=false flag
    */
-  test.skip('[mock] Access code submission is case-insensitive', async ({
+  test('[mock] Access code submission is case-insensitive', async ({
     loggedInPage: _loggedInPage,
     dashboardPage,
     enterAccessCodePage,

--- a/src/test/functional/specFiles/persistentSessionLogin.spec.ts
+++ b/src/test/functional/specFiles/persistentSessionLogin.spec.ts
@@ -38,15 +38,8 @@ test.describe('Persistent Session After Re-login', () => {
    * on the dashboard without re-entering case number or access code.
    * IDAM SSO re-authenticates and the linked case session is restored.
    * [mock] Uses hardcoded access codes injected via test session endpoint.
-   * 
-   * TODO: RESOLVE - Currently skipped due to implementation of invalidating access code (PR #347).
-   * The mock test framework does not properly mock the CCD triggerEvent() call required for access code invalidation.
-   * When a valid access code is submitted via navigateToLinkedDashboard(), the system now calls invalidateAccessCode() which triggers a CCD event.
-   * This test requires either:
-   * 1. Mock support for CCD API triggerEvent() in the test framework, or
-   * 2. Bypass access code invalidation in mock test mode via MOCK_INVALIDATE_ACCESS_CODE=false flag
    */
-  test.skip('[mock] User lands on dashboard after re-login without re-entering case details @a11y', async ({
+  test('[mock] User lands on dashboard after re-login without re-entering case details @a11y', async ({
     loggedInPage,
     basePage,
     dashboardPage,
@@ -80,15 +73,8 @@ test.describe('Persistent Session After Re-login', () => {
    * Verify that case session persists across multiple tabs/contexts
    * within the same authenticated session.
    * [mock] Uses hardcoded access codes injected via test session endpoint.
-   * 
-   * TODO: RESOLVE - Currently skipped due to implementation of invalidating access code (PR #347).
-   * The mock test framework does not properly mock the CCD triggerEvent() call required for access code invalidation.
-   * When a valid access code is submitted via navigateToLinkedDashboard(), the system now calls invalidateAccessCode() which triggers a CCD event.
-   * This test requires either:
-   * 1. Mock support for CCD API triggerEvent() in the test framework, or
-   * 2. Bypass access code invalidation in mock test mode via MOCK_INVALIDATE_ACCESS_CODE=false flag
    */
-  test.skip('[mock] Case session persists across multiple tabs in same browser context @a11y', async ({
+  test('[mock] Case session persists across multiple tabs in same browser context @a11y', async ({
     loggedInPage: _loggedInPage,
     basePage,
     dashboardPage,
@@ -117,15 +103,8 @@ test.describe('Persistent Session After Re-login', () => {
    * dashboard within the same session does not require re-entering case/access code.
    * (page.reload() is not used because a hard reload clears in-memory mock session state)
    * [mock] Uses hardcoded access codes injected via test session endpoint.
-   * 
-   * TODO: RESOLVE - Currently skipped due to implementation of invalidating access code (PR #347).
-   * The mock test framework does not properly mock the CCD triggerEvent() call required for access code invalidation.
-   * When a valid access code is submitted via navigateToLinkedDashboard(), the system now calls invalidateAccessCode() which triggers a CCD event.
-   * This test requires either:
-   * 1. Mock support for CCD API triggerEvent() in the test framework, or
-   * 2. Bypass access code invalidation in mock test mode via MOCK_INVALIDATE_ACCESS_CODE=false flag
    */
-  test.skip('[mock] Case session persists when navigating away and back to dashboard @a11y', async ({
+  test('[mock] Case session persists when navigating away and back to dashboard @a11y', async ({
     loggedInPage: _loggedInPage,
     basePage,
     dashboardPage,


### PR DESCRIPTION
### Jira link

See  [DFR-4986](https://tools.hmcts.net/jira/browse/DFR-4986)

### Change description

- The changes resolve a testing bottleneck where functional tests were failing because they couldn't communicate with the external CCD API.

- Bypassed API in Test Mode: Modified enter-access-code.ts to check for ENABLE_TEST_SUPPORT_ROUTES. If active, the system updates case data locally instead of making a real API call to invalidate access codes.

- Re-enabled Tests: Removed test.skip from 7 functional tests across enterAccessCode.spec.ts and persistentSessionLogin.spec.ts.

- Restored Test Coverage: These tests now verify "Happy Path" scenarios, whitespace trimming, case-insensitivity, and session persistence across tabs/re-logins.

- Reduced Technical Debt: Deleted large "TODO" blocks that previously documented why the tests were disabled.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
