### PR TITLE
Add unit test coverage for CCD event token & trigger event request flow

### DIFF
--- a/src/test/unit/app/case/case-api-client.test.ts
+++ b/src/test/unit/app/case/case-api-client.test.ts
@@ -274,6 +274,21 @@ const applicantAccessCodes = [
       EVENT_NAME
     );
 
+    expect(mockAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      UrlEndPoints.CaseEventTrigger(CASE_ID, EVENT_NAME)
+    );
+
+    expect(mockAxios.post).toHaveBeenCalledTimes(1);
+    expect(mockAxios.post).toHaveBeenCalledWith(
+      UrlEndPoints.CaseEvents(CASE_ID),
+      {
+        event: { id: EVENT_NAME },
+        data: { applicantAccessCodes },
+        event_token: 'event-token',
+      }
+    );
+
     expect(result).toEqual({
       id: CASE_ID,
       state: 'Submitted',
@@ -309,6 +324,9 @@ const applicantAccessCodes = [
     expect(mockLogger.info).toHaveBeenCalledWith(
       'retrying send event due to 409. this is retry no (1)'
     );
+
+    expect(mockAxios.get).toHaveBeenCalledTimes(2);
+    expect(mockAxios.post).toHaveBeenCalledTimes(2);
 
     expect(result).toEqual({
       id: CASE_ID,


### PR DESCRIPTION
### Jira link

See [DFR-4837](https://tools.hmcts.net/jira/browse/DFR-4837)

### Change description

Strengthened unit tests in [case-api-client.test.ts] to  verify the two-call CCD pattern in sendEvent:

- GET call to the event-trigger endpoint to fetch the event token.
- POST call to the events endpoint with event id, payload data, and event_token. 

### Testing done

Unit test added

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
